### PR TITLE
Add simplecov for test coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,8 @@
 !/log/.keep
 /tmp
 
+# Ignore simplecov reports
+coverage
+
+# Ignore stupid apple files
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ gem 'faker'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'simplecov', :require => false, :group => :test
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     coderay (1.1.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    docile (1.1.5)
     erubis (2.7.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
@@ -157,6 +158,11 @@ GEM
       rdoc (~> 4.0)
     shoulda-matchers (3.0.0)
       activesupport (>= 4.0.0)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     spring (1.4.0)
     sprockets (3.4.0)
@@ -193,6 +199,7 @@ DEPENDENCIES
   rspec-rails
   sdoc (~> 0.4.0)
   shoulda-matchers (~> 3.0)
+  simplecov
   spring
   web-console (~> 2.0)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,6 @@
+require 'simplecov'
+SimpleCov.start 'rails'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
Why . . . just because I was bored on the train, with nothing to do . . . :trumpet: 

Oh, you can see the coverage report by opening coverage/index.html.  It's very nice, with all the pretty colors and all. :stuck_out_tongue_winking_eye: 
