### PR TITLE
Unsecure dev

### DIFF
--- a/app/controllers/auth0_controller.rb
+++ b/app/controllers/auth0_controller.rb
@@ -40,7 +40,10 @@ class Auth0Controller < ApplicationController
     if response[:status] == "204 No Content"
       return true
     end
-    false
+    # false
+    # force return true to make dev-branch hosted at mentor-me-dev.herokuapp.com
+    # accessible to any user with a GitHub profile
+    true
   end
 
   def github_mentor?


### PR DESCRIPTION
This intentionally disbles the DBC org membership check via GitHub to allow any GitHub member to access the dev site hosted at mentor-me-dev.herokuapp.com.  This should obviously not be merged into master.
